### PR TITLE
Add support of field relashionsips on egg

### DIFF
--- a/pytero/types.py
+++ b/pytero/types.py
@@ -20,7 +20,6 @@ __all__ = (
     'DeployServerOptions',
     'EggScript',
     'EggConfiguration',
-    'EggRelashionships',
     'Egg',
     'FeatureLimits',
     'Limits',
@@ -210,16 +209,6 @@ class EggScript:
     entry: str
     container: str
     extends: Optional[str]
-
-    def to_dict(self) -> dict[str, Any]:
-        return self.__dict__
-
-
-@dataclass
-class EggRelashionships:
-    config: dict
-    script: dict
-    variables: dict
 
     def to_dict(self) -> dict[str, Any]:
         return self.__dict__

--- a/pytero/types.py
+++ b/pytero/types.py
@@ -20,6 +20,7 @@ __all__ = (
     'DeployServerOptions',
     'EggScript',
     'EggConfiguration',
+    'EggRelashionships',
     'Egg',
     'FeatureLimits',
     'Limits',
@@ -215,6 +216,16 @@ class EggScript:
 
 
 @dataclass
+class EggRelashionships:
+    config: dict
+    script: dict
+    variables: dict
+
+    def to_dict(self) -> dict[str, Any]:
+        return self.__dict__
+
+
+@dataclass
 class Egg:
     id: int
     uuid: str
@@ -229,7 +240,8 @@ class Egg:
     startup: str
     script: EggScript
     created_at: str
-    updated_at: Optional[str]
+    updated_at: Optional[str] = None
+    relationships: Optional[dict] = None
 
     def __repr__(self) -> str:
         return f'<Egg id={self.id} nest=#{self.nest} name={self.name}>'


### PR DESCRIPTION
This add support for the field `relashionsips` on the `Egg` models, useful for example when including more fields when using the `include` parameter from the eggs management endpoints

I also set a default values for the optional fields since a field must have a default value when using dataclass.

I also added a default argument for the field with the type `Optional`, since `dataclass` need a default value i think this will be requirement for the PyPI release https://github.com/PteroPackages/Pytero/issues/4